### PR TITLE
Smooth theme toggle — prevent flash and double-toggle

### DIFF
--- a/components/shared/theme-toggle.tsx
+++ b/components/shared/theme-toggle.tsx
@@ -8,14 +8,28 @@ import { useEffect, useState } from "react";
 export default function ModeToggle() {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const [isChanging, setIsChanging] = useState(false);
 
   // Wait for component to mount before rendering icons
   useEffect(() => {
     setMounted(true);
   }, []);
 
+  // Add smooth transition when theme changes
+  useEffect(() => {
+    if (mounted) {
+      document.documentElement.style.transition = "background-color 0.3s ease-in-out, color 0.3s ease-in-out";
+      return () => {
+        document.documentElement.style.transition = "";
+      };
+    }
+  }, [mounted]);
+
   const toggleTheme = () => {
+    setIsChanging(true);
     setTheme(theme === "light" ? "dark" : "light");
+    // Reset changing state after transition
+    setTimeout(() => setIsChanging(false), 300);
   };
 
   // Prevent rendering on server to avoid hydration mismatch
@@ -26,10 +40,19 @@ export default function ModeToggle() {
       onClick={toggleTheme}
       whileTap={{ rotate: 180 }}
       transition={{ duration: 0.3 }}
-      className="px-2 rounded-full transition  flex items-center justify-center"
+      className={`px-2 rounded-full transition-all duration-300 flex items-center justify-center ${
+        isChanging ? 'opacity-50' : 'opacity-100'
+      }`}
       aria-label="Toggle theme"
+      disabled={isChanging}
     >
-      {theme === "light" ? <Moon size={18} /> : <Sun size={18} />}
+      <motion.div
+        initial={false}
+        animate={{ rotate: theme === 'light' ? 0 : 180 }}
+        transition={{ duration: 0.3 }}
+      >
+        {theme === "light" ? <Moon size={18} /> : <Sun size={18} />}
+      </motion.div>
     </motion.button>
   );
 }


### PR DESCRIPTION
Dear @suryanshsingh2001 

Fixes #20

## Changes made
This PR implements smooth theme transitions and prevents double-toggle issues by:
- Adding `isChanging` state in `theme-toggle.tsx` to prevent rapid clicks
- Adding CSS transitions for smooth color changes (300ms)
- Improving icon animation with `framer-motion`

## Testing done
✅ Theme changes animate smoothly (300ms transition)
✅ No flash effect when switching themes
✅ Rapid clicks don't cause glitches
✅ No hydration warnings on page load
✅ Icon animates smoothly with rotation

## How to verify
1. `npm run dev` and open http://localhost:3000
2. Click theme toggle - colors should transition smoothly
3. Click rapidly - should handle clicks properly without glitches
4. Refresh page - should load correct theme without warnings

If you find this PR suitable for merging, I would be grateful if you could kindly add the `hacktoberfest-accepted` label to this PR (or the associated issue). This will ensure that my contribution is counted for Hacktoberfest and will greatly support my participation in the event.

Thank you very much for your time and consideration